### PR TITLE
build: update include paths for mingw64 on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ The API is a direct mapping to [libunbound calls][header].
   resolution (returns a `Promise`). `type` and `class` are raw qtypes and
   qclasses (no strings!). See above example for return value.
 
+## Building on Windows
+
+Windows builds are possible with MSYS2 / MinGW.
+
+1. Install MSYS2 from https://www.msys2.org - follow the instructions on that page
+2. Install dependencies - do one of the following in an MSYS2 shell
+   - x86_64: `pacman -S base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-unbound mingw-w64-x86_64-crt-git`
+   - x86: `pacman -S base-devel mingw-w64-i686-toolchain mingw-w64-i686-unbound mingw-w64-i686-crt-git`
+3. Then build normally from the MSYS2 shell.
+
 ## Contribution and License Agreement
 
 If you contribute code to this project, you are implicitly allowing your code

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,8 +16,14 @@
         }
       }],
       ["OS == 'win'", {
+        'include_dirs': [
+          'C:/msys64/mingw64/include'
+        ],
+        'library_dirs': [
+          'C:/msys64/mingw64/lib',
+        ],
         "libraries": [
-          "-lunbound.lib"
+          "-llibunbound.dll.a"
         ]
       }, {
         "libraries": [


### PR DESCRIPTION
I was finally able to get this package to build on windows in msys2/mingw64. I used the package manager to install libunbound but then had to modify binding.gyp to include the right directories. The library name is also a bit different. I couldn't find a better way to do this, I'm not sure if the existing settings in binding.gyp were ever right or if there's a more flexible way to do this with, say, environment variables. I tried everything else! 